### PR TITLE
Fix mamba/micromamba initialization commands for Debian/Ubuntu users

### DIFF
--- a/recipe/0002-byobu-conda.diff
+++ b/recipe/0002-byobu-conda.diff
@@ -233,10 +233,10 @@ index 8aaaaf3f..4a519106 100755
 +		. "/${conda_sh}"
 +	elif type mamba >/dev/null 2>&1; then
 +		# Some users install byobu using mamba
-+		eval "$(mamba shell hook --shell ${SHELL##*/})"
++		eval "$(mamba shell hook --shell posix)"
 +	elif type micromamba >/dev/null 2>&1; then
 +		# Some users install byobu using micromamba
-+		eval "$(micromamba shell hook --shell ${SHELL##*/})"
++		eval "$(micromamba shell hook --shell posix)"
 +	else
 +		echo "WARNING: Please source etc/profile.d/conda.sh first."
 +		echo "WARNING: Alternatively, activate the byobu environment and call byobu-enable-conda"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0003-byobu-conda-update.diff
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
To avoid the potential `eval: Syntax error: "(" unexpected (expecting "}")`. On Debian/Ubuntu, the `/bin/sh` used by Byobu scripts is actually Dash, which is POSIX-compliant but not Bash-compatible, while Bash is likely still the default user shell for `${SHELL}`.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
